### PR TITLE
Remove unnecessary "throws Exception" from constructors

### DIFF
--- a/src/main/java/fm/jiecao/lib/Hashids.java
+++ b/src/main/java/fm/jiecao/lib/Hashids.java
@@ -24,19 +24,19 @@ public class Hashids {
   private int minAlphabetLength = 16;
   private String guards;
 
-  public Hashids() throws Exception {
+  public Hashids() {
     this("");
   }
 
-  public Hashids(String salt) throws Exception {
+  public Hashids(String salt) {
     this(salt, 0);
   }
 
-  public Hashids(String salt, int minHashLength) throws Exception {
+  public Hashids(String salt, int minHashLength) {
     this(salt, minHashLength, DEFAULT_ALPHABET);
   }
 
-  public Hashids(String salt, int minHashLength, String alphabet) throws Exception {
+  public Hashids(String salt, int minHashLength, String alphabet) {
     this.salt = salt;
     if(minHashLength < 0)
       this.minHashLength = 0;


### PR DESCRIPTION
because none of the constructors actually throws a checked exception.
