### PR TITLE
Add configurable hash mod base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/hashids/Hashids.java
+++ b/src/main/java/org/hashids/Hashids.java
@@ -31,12 +31,14 @@ public class Hashids {
   private static final int MIN_ALPHABET_LENGTH = 16;
   private static final double SEP_DIV = 3.5;
   private static final int GUARD_DIV = 12;
+  private static final int DEFAULT_HASH_MOD_BASE = 100;
 
   private final String salt;
   private final int minHashLength;
   private final String alphabet;
   private final String seps;
   private final String guards;
+  private final int hashModBase;
 
   public Hashids() {
     this(DEFAULT_SALT);
@@ -47,12 +49,21 @@ public class Hashids {
   }
 
   public Hashids(String salt, int minHashLength) {
-    this(salt, minHashLength, DEFAULT_ALPHABET);
+    this(salt, minHashLength, DEFAULT_ALPHABET, DEFAULT_HASH_MOD_BASE);
   }
 
+  public Hashids(String salt, int minHashLength, int hashModBase) {
+	    this(salt, minHashLength, DEFAULT_ALPHABET, hashModBase);
+	  }
+
   public Hashids(String salt, int minHashLength, String alphabet) {
+    this(salt, minHashLength, alphabet, DEFAULT_HASH_MOD_BASE);
+  }
+
+  public Hashids(String salt, int minHashLength, String alphabet, int hashModBase) {
     this.salt = salt != null ? salt : DEFAULT_SALT;
     this.minHashLength = minHashLength > 0 ? minHashLength : DEFAULT_MIN_HASH_LENGTH;
+    this.hashModBase = hashModBase != 0? hashModBase : DEFAULT_HASH_MOD_BASE;
 
     final StringBuilder uniqueAlphabet = new StringBuilder();
     for (int i = 0; i < alphabet.length(); i++) {
@@ -226,7 +237,7 @@ public class Hashids {
   private String _encode(long... numbers) {
     long numberHashInt = 0;
     for (int i = 0; i < numbers.length; i++) {
-      numberHashInt += (numbers[i] % (i + 100));
+      numberHashInt += (numbers[i] % (i + hashModBase));
     }
     String alphabet = this.alphabet;
     final char ret = alphabet.charAt((int) (numberHashInt % alphabet.length()));


### PR DESCRIPTION
When generating hashes that are separated by 100 the hash strings are very similar. This is unavoidable with this implementation and perhaps not a huge deal, but maybe it would be best if the periodicity were a number that is not so "tidy". This PR adds the ability to construct the class with a user-specified hash mod base. I personally would use a similarly large prime number, like 97. The strings are very similar for every 97 ids, but this is probably less likely to be noticed.

Also increase JUnit 4 version to avoid CVE flagging